### PR TITLE
allow grouping multiple view functions into one elm file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,73 @@ elmStaticHtml("/absolute/path/to/elm-package.json", "MyModule.view", options)
 
 ```
 
+## multiple at once
+
+When you want to render many views - particularly when they share dependencies - it is faster to use the `multiple` function.
+
+```javascript
+const configs = [ 
+    { viewFunction: "MyModule.view", model, decoder: "MyModule.decodeModel", fileOutputName: "grouped1.html" }, 
+    { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", fileOutputName: "grouped2.html" }, 
+    ];
+
+elmStaticHtml.multiple("/absolute/path/to/elm-package.json", configs)
+.then((generatedHtmls) => {
+    generatedHtmls
+        .map((output) => fs.writeFileSync(output.fileOutputName, output.generatedHtml));
+});
+```
+
+
 ### API description
 
 ```js
 elmStaticHtml(packagePath, viewFunction, options)
 ```
 
-- **packagePath** *(String)*: an absolute path to the `elm-package.json` of your project.
+- **packagePath** *(String)*: An absolute path to the `elm-package.json` of your project.
 - **viewFunction** *(String)*: [Qualified name](https://guide.elm-lang.org/reuse/modules.html) to the view function. Format `<ModuleName>.<functionName>`
 - **options** *(object)*: A map of options. Can be either empty or contain a model and a qualified decoder name. See above for usage details.
+
+```js
+elmStaticHtml.multiple(packagePath, configs)
+```
+
+- **packagePath** *(String)*: An absolute path to the `elm-package.json` of your project.
+- **configs** *ViewFunctionConfig[]*: An array of configurations, see below.
+- **alreadyRun?** *(Boolean)*: When true, doesn't generate boilerplate again. Useful if only your models have changed, and not your elm code.
+- **elmMakePath?** *(String)*: Specify the path to elm-make.
+- **installMethod** *(String)*: Specify a custom package installation command.
+
+**returns** *Output*: An object containing the generated html and the outputFileName.
+
+```typescript
+export interface ViewFunctionConfig {
+    viewFunction: string;
+    fileOutputName: string;
+    model?: any;
+    decoder?: string;
+    indent?: number;
+    newLines?: boolean;
+}
+```
+
+- **viewFunction**: [Qualified name](https://guide.elm-lang.org/reuse/modules.html) to the view function. Format `<ModuleName>.<functionName>`
+- **fileOutputName**: File name. This value is not touched and given back to `Output`, to make saving the generated html easier
+- **model?**: Optional object that is given as the model to your view function
+- **decoder?**: [Qualified name](https://guide.elm-lang.org/reuse/modules.html) to the decoder for `model`. Format `<ModuleName>.<decoderName>`
+- **indent?**: Optional formatting flag. Sets whether the generated html should be indented (default true)
+- **newLines?**: Optional formatting flag. Sets whether new tags should start on a new line when (default true)
+
+```typescript
+export interface Output {
+    generatedHtml: string;
+    fileOutputName: string;
+}
+```
+
+- **generatedHtml**: The html that your view has produced
+- **fileOutputName**: A file name that is threaded through for convenience
 
 
 ### More examples

--- a/example/index.ts
+++ b/example/index.ts
@@ -45,9 +45,9 @@ runLazyView();
 
 function runMultiple() {
     const configs =
-        [ { viewFunction: "MyModule.view", model, decoder: "MyModule.decodeModel", filename: "grouped1.html" }
-        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", filename: "grouped2.html" }
-        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", filename: "grouped3.html" }
+        [ { viewFunction: "MyModule.view", model, decoder: "MyModule.decodeModel", fileOutputName: "grouped1.html" }
+        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", fileOutputName: "grouped2.html" }
+        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", fileOutputName: "grouped3.html" }
         ];
 
     elmStaticHtml.multiple(process.cwd(), configs)

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,5 @@
 import elmStaticHtml from "../index";
+import { elmStaticHtmlMultiple} from "../index";
 import * as fs from "fs";
 
 const model = { name: "Noah", age : 24 };
@@ -6,6 +7,7 @@ const secondModel = { name: "not noah", age: 74};
 const firstRunOptions = { model : model, decoder: "MyModule.decodeModel", alreadyRun: false };
 const secondRunOptions = { model : secondModel, decoder: "MyModule.decodeModel", alreadyRun: true };
 
+/*
 
 function runTwice() {
     elmStaticHtml(process.cwd(), "MyModule.view", firstRunOptions)
@@ -24,6 +26,8 @@ function runTwice() {
 
 runTwice();
 
+ */
+
 
 function runWithoutModel() {
     elmStaticHtml(process.cwd(), "MyModule.otherView", {})
@@ -34,6 +38,7 @@ function runWithoutModel() {
 
 runWithoutModel();
 
+/*
 
 function runLazyView() {
     elmStaticHtml(process.cwd(), "MyModule.lazyView", firstRunOptions)
@@ -45,3 +50,17 @@ function runLazyView() {
 } 
 
 runLazyView();
+
+ */
+function runMultiple() { 
+    const configs = 
+        [ { viewFunction: "MyModule.view", model: model
+            , decoder: "MyModule.decodeModel", output: "multiple1.html" } 
+            , { viewFunction: "MyModule.lazyView", model: model
+            , decoder: "MyModule.decodeModel", output: "multiple2.html" } 
+        ];
+
+    elmStaticHtmlMultiple(process.cwd(), "MyModule", configs);
+}
+
+runMultiple();

--- a/example/index.ts
+++ b/example/index.ts
@@ -37,7 +37,6 @@ function runWithoutModel() {
 
 runWithoutModel();
 
-/*
 function runLazyView() {
     elmStaticHtml.default(process.cwd(), "MyModule.lazyView", firstRunOptions)
     .then((generatedHtml) => {
@@ -46,7 +45,6 @@ function runLazyView() {
         console.log(err);
     });
 } 
-*/
 
 runLazyView();
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -43,18 +43,18 @@ function runLazyView() {
 
 runLazyView();
 
-function runGrouped() {
+function runMultiple() {
     const configs =
         [ { viewFunction: "MyModule.view", model, decoder: "MyModule.decodeModel", output: "grouped1.html" }
         , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", output: "grouped2.html" }
         , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", output: "grouped3.html" }
         ];
 
-    elmStaticHtml.grouped(process.cwd(), "MyModule", configs)
+    elmStaticHtml.multiple(process.cwd(), "MyModule", configs)
         .then((generatedHtmls) => {
             generatedHtmls
                 .map((generatedHtml, i) => fs.writeFileSync(configs[i].output, generatedHtml));
         });
 }
 
-runGrouped();
+runMultiple();

--- a/example/index.ts
+++ b/example/index.ts
@@ -38,28 +38,29 @@ function runWithoutModel() {
 runWithoutModel();
 
 /*
-
 function runLazyView() {
-    elmStaticHtml(process.cwd(), "MyModule.lazyView", firstRunOptions)
+    elmStaticHtml.default(process.cwd(), "MyModule.lazyView", firstRunOptions)
     .then((generatedHtml) => {
         fs.writeFileSync("output5.html", generatedHtml);
     }).catch((err) =>{
         console.log(err);
     });
 } 
+*/
 
 runLazyView();
 
- */
-function runMultiple() { 
-    const configs = 
-        [ { viewFunction: "MyModule.view", model: model
-            , decoder: "MyModule.decodeModel", output: "multiple1.html" } 
-            , { viewFunction: "MyModule.lazyView", model: model
-            , decoder: "MyModule.decodeModel", output: "multiple2.html" } 
+function runMultiple() {
+    const configs =
+        [ { viewFunction: "MyModule.view", model, decoder: "MyModule.decodeModel", output: "multiple1.html" }
+        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", output: "multiple2.html" }
         ];
 
-    elmStaticHtml.grouped(process.cwd(), "MyModule", configs);
+    elmStaticHtml.grouped(process.cwd(), "MyModule", configs)
+        .then((generatedHtmls) => {
+            generatedHtmls
+                .map((generatedHtml, i) => fs.writeFileSync(configs[i].output, generatedHtml));
+        });
 }
 
 runMultiple();

--- a/example/index.ts
+++ b/example/index.ts
@@ -50,10 +50,10 @@ function runMultiple() {
         , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", filename: "grouped3.html" }
         ];
 
-    elmStaticHtml.multiple(process.cwd(), "MyModule", configs)
+    elmStaticHtml.multiple(process.cwd(), configs)
         .then((generatedHtmls) => {
             generatedHtmls
-                .map((generatedHtml, i) => fs.writeFileSync(configs[i].output, generatedHtml));
+                .map((output) => fs.writeFileSync(output.fileOutputName, output.generatedHtml));
         });
 }
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -37,6 +37,7 @@ function runWithoutModel() {
 
 runWithoutModel();
 
+/*
 function runLazyView() {
     elmStaticHtml.default(process.cwd(), "MyModule.lazyView", firstRunOptions)
     .then((generatedHtml) => {
@@ -45,6 +46,7 @@ function runLazyView() {
         console.log(err);
     });
 } 
+*/
 
 runLazyView();
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import * as elmStaticHtml from "../index";
+import { elmStaticHtml, multiple } from "../index";
 
 const model = { name: "Noah", age : 24 };
 const secondModel = { name: "not noah", age: 74};
@@ -7,13 +7,13 @@ const firstRunOptions = { model : model, decoder: "MyModule.decodeModel", alread
 const secondRunOptions = { model : secondModel, decoder: "MyModule.decodeModel", alreadyRun: true };
 
 function runTwice() {
-    elmStaticHtml.default(process.cwd(), "MyModule.view", firstRunOptions)
+    elmStaticHtml(process.cwd(), "MyModule.view", firstRunOptions)
     .then((generatedHtml) => {
         fs.writeFileSync("output.html", generatedHtml);
-        elmStaticHtml.default(process.cwd(), "MyModule.view", secondRunOptions)
+        elmStaticHtml(process.cwd(), "MyModule.view", secondRunOptions)
         .then((generatedHtml) => {
             fs.writeFileSync("output2.html", generatedHtml);
-            elmStaticHtml.default(process.cwd(), "MyModule.view", secondRunOptions)
+            elmStaticHtml(process.cwd(), "MyModule.view", secondRunOptions)
             .then((generatedHtml) => {
                 fs.writeFileSync("output3.html", generatedHtml);
             });
@@ -24,7 +24,7 @@ function runTwice() {
 runTwice();
 
 function runWithoutModel() {
-    elmStaticHtml.default(process.cwd(), "MyModule.otherView", {})
+    elmStaticHtml(process.cwd(), "MyModule.otherView", {})
     .then((generatedHtml) => {
         fs.writeFileSync("output4.html", generatedHtml);
     });
@@ -33,7 +33,7 @@ function runWithoutModel() {
 runWithoutModel();
 
 function runLazyView() {
-    elmStaticHtml.default(process.cwd(), "MyModule.lazyView", firstRunOptions)
+    elmStaticHtml(process.cwd(), "MyModule.lazyView", firstRunOptions)
     .then((generatedHtml) => {
         fs.writeFileSync("output5.html", generatedHtml);
     }).catch((err) => {
@@ -50,7 +50,7 @@ function runMultiple() {
         , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", fileOutputName: "grouped3.html" }
         ];
 
-    elmStaticHtml.multiple(process.cwd(), configs)
+    multiple(process.cwd(), configs)
         .then((generatedHtmls) => {
             generatedHtmls
                 .map((output) => fs.writeFileSync(output.fileOutputName, output.generatedHtml));

--- a/example/index.ts
+++ b/example/index.ts
@@ -45,9 +45,9 @@ runLazyView();
 
 function runMultiple() {
     const configs =
-        [ { viewFunction: "MyModule.view", model, decoder: "MyModule.decodeModel", output: "grouped1.html" }
-        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", output: "grouped2.html" }
-        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", output: "grouped3.html" }
+        [ { viewFunction: "MyModule.view", model, decoder: "MyModule.decodeModel", filename: "grouped1.html" }
+        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", filename: "grouped2.html" }
+        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", filename: "grouped3.html" }
         ];
 
     elmStaticHtml.multiple(process.cwd(), "MyModule", configs)

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,5 +1,4 @@
-import elmStaticHtml from "../index";
-import { elmStaticHtmlMultiple} from "../index";
+import * as elmStaticHtml from "../index";
 import * as fs from "fs";
 
 const model = { name: "Noah", age : 24 };
@@ -30,7 +29,7 @@ runTwice();
 
 
 function runWithoutModel() {
-    elmStaticHtml(process.cwd(), "MyModule.otherView", {})
+    elmStaticHtml.default(process.cwd(), "MyModule.otherView", {})
     .then((generatedHtml) => {
         fs.writeFileSync("output4.html", generatedHtml);
     });
@@ -60,7 +59,7 @@ function runMultiple() {
             , decoder: "MyModule.decodeModel", output: "multiple2.html" } 
         ];
 
-    elmStaticHtmlMultiple(process.cwd(), "MyModule", configs);
+    elmStaticHtml.grouped(process.cwd(), "MyModule", configs);
 }
 
 runMultiple();

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,21 +1,19 @@
-import * as elmStaticHtml from "../index";
 import * as fs from "fs";
+import * as elmStaticHtml from "../index";
 
 const model = { name: "Noah", age : 24 };
 const secondModel = { name: "not noah", age: 74};
 const firstRunOptions = { model : model, decoder: "MyModule.decodeModel", alreadyRun: false };
 const secondRunOptions = { model : secondModel, decoder: "MyModule.decodeModel", alreadyRun: true };
 
-/*
-
 function runTwice() {
-    elmStaticHtml(process.cwd(), "MyModule.view", firstRunOptions)
+    elmStaticHtml.default(process.cwd(), "MyModule.view", firstRunOptions)
     .then((generatedHtml) => {
         fs.writeFileSync("output.html", generatedHtml);
-        elmStaticHtml(process.cwd(), "MyModule.view", secondRunOptions)
+        elmStaticHtml.default(process.cwd(), "MyModule.view", secondRunOptions)
         .then((generatedHtml) => {
             fs.writeFileSync("output2.html", generatedHtml);
-            elmStaticHtml(process.cwd(), "MyModule.view", secondRunOptions)
+            elmStaticHtml.default(process.cwd(), "MyModule.view", secondRunOptions)
             .then((generatedHtml) => {
                 fs.writeFileSync("output3.html", generatedHtml);
             });
@@ -24,9 +22,6 @@ function runTwice() {
 }
 
 runTwice();
-
- */
-
 
 function runWithoutModel() {
     elmStaticHtml.default(process.cwd(), "MyModule.otherView", {})
@@ -37,23 +32,22 @@ function runWithoutModel() {
 
 runWithoutModel();
 
-/*
 function runLazyView() {
     elmStaticHtml.default(process.cwd(), "MyModule.lazyView", firstRunOptions)
     .then((generatedHtml) => {
         fs.writeFileSync("output5.html", generatedHtml);
-    }).catch((err) =>{
+    }).catch((err) => {
         console.log(err);
     });
-} 
-*/
+}
 
 runLazyView();
 
-function runMultiple() {
+function runGrouped() {
     const configs =
-        [ { viewFunction: "MyModule.view", model, decoder: "MyModule.decodeModel", output: "multiple1.html" }
-        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", output: "multiple2.html" }
+        [ { viewFunction: "MyModule.view", model, decoder: "MyModule.decodeModel", output: "grouped1.html" }
+        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", output: "grouped2.html" }
+        , { viewFunction: "MyModule.lazyView", model, decoder: "MyModule.decodeModel", output: "grouped3.html" }
         ];
 
     elmStaticHtml.grouped(process.cwd(), "MyModule", configs)
@@ -63,4 +57,4 @@ function runMultiple() {
         });
 }
 
-runMultiple();
+runGrouped();

--- a/example/output.html
+++ b/example/output.html
@@ -1,1 +1,4 @@
-I could not decode the argument for MyModule.view:Expecting an object with a field named `age` but instead got: undefined
+<div>
+    I am Noah
+    And I am 24 years old.
+</div>

--- a/example/output.html
+++ b/example/output.html
@@ -1,4 +1,1 @@
-<div>
-    I am Noah
-    And I am 24 years old.
-</div>
+I could not decode the argument for MyModule.view:Expecting an object with a field named `age` but instead got: undefined

--- a/index.ts
+++ b/index.ts
@@ -84,7 +84,6 @@ function makeHash(viewFunction: string): string {
 
 export interface ViewFunctionConfig {
     viewFunction: string;
-    output: string;
     model?: any;
     decoder?: string;
     indent?: number;
@@ -95,15 +94,13 @@ export interface ViewFunctionConfig {
 // which is much faster if you're likely to need all of them
 export function grouped(
     rootDir: string, moduleName: string, configs: ViewFunctionConfig[],
-    alreadyRun?: boolean, elmMakePath?: string, installMethod?: string): Promise<void[]> {
+    alreadyRun?: boolean, elmMakePath?: string, installMethod?: string): Promise<string[]> {
     const moduleHash = makeHash(moduleName);
 
     const dirPath = path.join(rootDir, renderDirName);
 
-    const models = configs.map((config) => config.model);
-
     if (alreadyRun === true) {
-        const runs = models.map((config) => runElmAppConfig(moduleHash, config, rootDir));
+        const runs = configs.map((config) => runElmAppConfig(moduleHash, config, dirPath));
         return Promise.all(runs);
     }
 
@@ -234,15 +231,13 @@ function runCompiler(viewHash: string,
     });
 }
 
-function runElmAppConfig(moduleHash: string, config: ViewFunctionConfig, rootDir: string): Promise<void> {
-    return (runElmApp(moduleHash, makeHash(config.viewFunction), rootDir, config.model)
-        .then((generatedHtml) => fs.writeFileSync(config.output, generatedHtml))
-    );
+function runElmAppConfig(moduleHash: string, config: ViewFunctionConfig, rootDir: string): Promise<string> {
+    return runElmApp(moduleHash, makeHash(config.viewFunction), rootDir, config.model);
 }
 
 function runCompilerMany(moduleHash: string,
                          privateMainPath: string,
-                         rootDir: string, configs: ViewFunctionConfig[], elmMakePath?: string): Promise<void[]> {
+                         rootDir: string, configs: ViewFunctionConfig[], elmMakePath?: string): Promise<string[]> {
     const options: any = {
         cwd: rootDir,
         output: "elm.js",

--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,7 @@ function parseProjectName(repoName: string): string {
 function runElmApp(moduleHash: string, viewHash: string, dirPath: string, model: any): Promise<string> {
 
     return new Promise((resolve, reject) => {
-        const Elm = require(path.join(dirPath, `elm${moduleHash}.js`));
+        const Elm = require(path.join(dirPath, "elm.js"));
         const privateName = `PrivateMain${moduleHash}`;
 
         if (Object.keys(Elm).indexOf(privateName) === - 1) {
@@ -205,7 +205,7 @@ function runCompiler(viewHash: string,
                      privateMainPath: string, rootDir: string, model: any, elmMakePath?: string): Promise<string> {
     const options: any = {
         cwd: rootDir,
-        output: `elm${viewHash}.js`,
+        output: "elm.js",
         yes: true,
     };
 
@@ -240,7 +240,7 @@ function runCompilerMany(moduleHash: string,
                          rootDir: string, configs: ViewFunctionConfig[], elmMakePath?: string): Promise<string[]> {
     const options: any = {
         cwd: rootDir,
-        output: `elm${moduleHash}.js`,
+        output: "elm.js",
         yes: true,
     };
 

--- a/index.ts
+++ b/index.ts
@@ -215,7 +215,7 @@ function runCompiler(viewHash: string,
 
     return new Promise((resolve, reject) => {
         fs.readdir(rootDir, (err, files) => {
-            const actualFiles = files.filter((name) => name.indexOf(`PrivateMain${viewHash}`) === 0);
+            const actualFiles = files.filter((name) => name.indexOf("PrivateMain") === 0);
 
             const compileProcess = compile(actualFiles, options);
             compileProcess.on("exit",
@@ -250,7 +250,7 @@ function runCompilerMany(moduleHash: string,
 
     return new Promise((resolve, reject) => {
         fs.readdir(rootDir, (err, files) => {
-            const actualFiles = files.filter((name) => name.indexOf(`PrivateMain${moduleHash}`) === 0);
+            const actualFiles = files.filter((name) => name.indexOf("PrivateMain") === 0);
 
             const compileProcess = compile(actualFiles, options);
             compileProcess.on("exit",

--- a/index.ts
+++ b/index.ts
@@ -91,7 +91,9 @@ export interface ViewFunctionConfig {
     newLines?: boolean;
 }
 
-export function elmStaticHtmlMultiple(
+// compiles multiple view functions into one elm file
+// which is much faster if you're likely to need all of them
+export function grouped(
     rootDir: string, moduleName: string, configs: ViewFunctionConfig[],
     alreadyRun?: boolean, elmMakePath?: string, installMethod?: string): Promise<void[]> {
     const moduleHash = makeHash(moduleName);
@@ -102,7 +104,6 @@ export function elmStaticHtmlMultiple(
 
     if (alreadyRun === true) {
         const runs = models.map((config) => runElmAppConfig(moduleHash, config, rootDir));
-        // return runElmApp(moduleHash, rootDir, model).then(resolve);
         return Promise.all(runs);
     }
 

--- a/index.ts
+++ b/index.ts
@@ -148,16 +148,17 @@ export function multiple(
     });
 }
 
-export default function elmStaticHtml(rootDir: string, viewFunction: string, options: Options): Promise<string> {
+export function elmStaticHtml(rootDir: string, viewFunction: string, options: Options): Promise<string> {
     const viewHash = makeHash(viewFunction);
 
-    const config = { decoder: options.decoder
-        , fileOutputName: "placeholder"
-        , indent: options.indent
-        , model: options.model
-        , newLines: options.newLines
-        , viewFunction
-        , viewHash};
+    const config = { decoder: options.decoder,
+        fileOutputName: "placeholder",
+        indent: options.indent,
+        model: options.model,
+        newLines: options.newLines,
+        viewFunction,
+        viewHash,
+    };
 
     const dirPath = path.join(rootDir, renderDirName);
 

--- a/index.ts
+++ b/index.ts
@@ -78,7 +78,7 @@ function makeHash(viewFunction: string): string {
 
 export interface ViewFunctionConfig {
     viewFunction: string;
-    filename: string;
+    fileOutputName: string;
     model?: any;
     decoder?: string;
     indent?: number;
@@ -102,7 +102,7 @@ export function multiple(
     const dirPath = path.join(rootDir, renderDirName);
 
     if (alreadyRun === true) {
-        const filenamesAndModels = configs.map((config) => [config.filename, config.model]);
+        const filenamesAndModels = configs.map((config) => [config.fileOutputName, config.model]);
         return runElmApp(moduleHash, dirPath, filenamesAndModels);
     }
 
@@ -152,7 +152,7 @@ export default function elmStaticHtml(rootDir: string, viewFunction: string, opt
     const viewHash = makeHash(viewFunction);
 
     const config = { decoder: options.decoder
-        , filename: "placeholder"
+        , fileOutputName: "placeholder"
         , indent: options.indent
         , model: options.model
         , newLines: options.newLines
@@ -162,7 +162,7 @@ export default function elmStaticHtml(rootDir: string, viewFunction: string, opt
     const dirPath = path.join(rootDir, renderDirName);
 
     if (options.alreadyRun === true) {
-        return runElmApp(viewHash, dirPath, [[config.filename, options.model]])
+        return runElmApp(viewHash, dirPath, [[config.fileOutputName, options.model]])
             .then((outputs) => outputs[0].generatedHtml);
     }
 
@@ -238,7 +238,7 @@ function runCompiler(moduleHash: string,
                     }
 
                     const runs = runElmApp(moduleHash, rootDir,
-                        configs.map((config) => [config.filename, config.model]));
+                        configs.map((config) => [config.fileOutputName, config.model]));
 
                     return runs.then(resolve);
                 },

--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,7 @@ function parseProjectName(repoName: string): string {
 function runElmApp(moduleHash: string, viewHash: string, dirPath: string, model: any): Promise<string> {
 
     return new Promise((resolve, reject) => {
-        const Elm = require(path.join(dirPath, "elm.js"));
+        const Elm = require(path.join(dirPath, `elm${moduleHash}.js`));
         const privateName = `PrivateMain${moduleHash}`;
 
         if (Object.keys(Elm).indexOf(privateName) === - 1) {
@@ -205,7 +205,7 @@ function runCompiler(viewHash: string,
                      privateMainPath: string, rootDir: string, model: any, elmMakePath?: string): Promise<string> {
     const options: any = {
         cwd: rootDir,
-        output: "elm.js",
+        output: `elm${viewHash}.js`,
         yes: true,
     };
 
@@ -240,7 +240,7 @@ function runCompilerMany(moduleHash: string,
                          rootDir: string, configs: ViewFunctionConfig[], elmMakePath?: string): Promise<string[]> {
     const options: any = {
         cwd: rootDir,
-        output: "elm.js",
+        output: `elm${moduleHash}.js`,
         yes: true,
     };
 

--- a/index.ts
+++ b/index.ts
@@ -86,7 +86,7 @@ export interface ViewFunctionConfig {
 
 // compiles multiple view functions into one elm file
 // which is much faster if you're likely to need all of them
-export function grouped(
+export function multiple(
     rootDir: string, moduleName: string, configs: ViewFunctionConfig[],
     alreadyRun?: boolean, elmMakePath?: string, installMethod?: string): Promise<string[]> {
     const moduleHash = makeHash(moduleName);

--- a/index.ts
+++ b/index.ts
@@ -215,7 +215,7 @@ function runCompiler(viewHash: string,
 
     return new Promise((resolve, reject) => {
         fs.readdir(rootDir, (err, files) => {
-            const actualFiles = files.filter((name) => name.indexOf("PrivateMain") === 0);
+            const actualFiles = files.filter((name) => name.indexOf(`PrivateMain${viewHash}`) === 0);
 
             const compileProcess = compile(actualFiles, options);
             compileProcess.on("exit",
@@ -250,7 +250,7 @@ function runCompilerMany(moduleHash: string,
 
     return new Promise((resolve, reject) => {
         fs.readdir(rootDir, (err, files) => {
-            const actualFiles = files.filter((name) => name.indexOf("PrivateMain") === 0);
+            const actualFiles = files.filter((name) => name.indexOf(`PrivateMain${moduleHash}`) === 0);
 
             const compileProcess = compile(actualFiles, options);
             compileProcess.on("exit",

--- a/templates.ts
+++ b/templates.ts
@@ -31,7 +31,32 @@ function functionName(functionLine: string): string {
     return functionLine.substr(functionLine.lastIndexOf("."));
 }
 
+function init(configs: ViewFunctionConfig[]): string {
+    const renderNames = configs.map((config) => "render" + config.viewHash);
+    return `
+init : Json.Value -> ((), Cmd msg)
+init values =
+    let command =
+            [ ${ renderNames } ]
+                |> List.map (\\renderer -> renderer values)
+                |> Cmd.batch
+    in
+        ((), command)
+`;
+
+}
+
 function initBodyWithDecoder(viewHash: string, viewFunction: string, decoderName: string): string {
+    return `
+init : Json.Value -> ((), Cmd msg)
+init values =
+    case Json.decodeValue ${decoderName} values of
+        Err err -> ((), htmlOut${viewHash} ("ERROR:" ++ err))
+        Ok model ->
+            ((), render${viewHash} model)
+`;
+}
+    /*
     return `
 init : Json.Value -> ((), Cmd msg)
 init values =
@@ -41,31 +66,25 @@ init values =
             ((), htmlOut${viewHash} <| decode <| ${viewFunction} model)
 `;
 }
+     */
 
 function initBodyWithoutDecoder(viewHash: string, viewFunction: string): string {
+    return `
+init : Json.Value -> ((), Cmd msg)
+init _ =
+    ((), render${viewHash})
+`;
+}
+    /*
     return `
 init : Json.Value -> ((), Cmd msg)
 init _ =
     ((), htmlOut${viewHash} <| decode <| ${viewFunction})
 `;
 }
+     */
 
-// this is our render's file contents
-// basically just boilerplate
-export function generateRendererFile(
-    viewHash: string, viewFunction: string, decoderName: string, newLines: boolean, indent: number): string {
-    let imports = importLine(viewFunction) + "\n";
-    if (decoderName) {
-        imports += importLine(decoderName);
-    }
-
-    let initBody;
-    if (decoderName) {
-        initBody = initBodyWithDecoder(viewHash, viewFunction, decoderName);
-    } else {
-        initBody = initBodyWithoutDecoder(viewHash, viewFunction);
-    }
-
+function generateOptionsSet(newLines: boolean, indent: number): string {
     let newLinesStr;
     if (newLines === undefined || newLines === true) {
       newLinesStr = "True";
@@ -75,10 +94,104 @@ export function generateRendererFile(
 
     const indentStr = indent !== undefined ? indent : 4;
 
-    const optionsSet = `options = { defaultFormatOptions | newLines = ${newLinesStr}, indent = ${indentStr} }`;
+    return `options = { defaultFormatOptions | newLines = ${newLinesStr}, indent = ${indentStr} }`;
+}
+
+export interface ViewFunctionConfig {
+    viewFunction: string;
+    viewHash: string;
+    model?: any;
+    decoder?: string;
+    indent?: number;
+    newLines?: boolean;
+}
+
+function renderCommandWithDecoder(viewHash: string, viewFunction: string, decoderName: string, optionsSet: string) {
+    return `
+render${viewHash} : Json.Value -> Cmd msg
+render${viewHash} values =
+    let
+        ${optionsSet}
+
+        decode : Html msg -> String
+        decode view =
+            case Json.decodeValue decodeElmHtml (asJsonView view) of
+                Err str -> "ERROR:" ++ str
+                Ok str -> nodeToStringWithOptions options str
+    in
+        case Json.decodeValue ${decoderName} values of
+            Err err ->
+                htmlOut${viewHash} ("I could not decode the argument for ${viewFunction}:" ++ err)
+
+            Ok model ->
+                htmlOut${viewHash} <| decode <| ${viewFunction} model
+        `;
+        }
+
+function renderCommandWithoutDecoder(viewHash: string, viewFunction: string, optionsSet: string) {
+    return `
+render${viewHash} : Json.Value -> Cmd msg
+render${viewHash} _ =
+    let
+        ${optionsSet}
+
+        decode : Html msg -> String
+        decode view =
+            case Json.decodeValue decodeElmHtml (asJsonView view) of
+                Err str -> "ERROR:" ++ str
+                Ok str -> nodeToStringWithOptions options str
+    in
+        htmlOut${viewHash} <| decode <| ${viewFunction}
+        `;
+}
+
+function generateBody(config: ViewFunctionConfig): string {
+    const optionsSet = generateOptionsSet(config.newLines, config.indent);
+    if (config.decoder) {
+        return renderCommandWithDecoder(config.viewHash, config.viewFunction, config.decoder, optionsSet);
+    } else {
+        return renderCommandWithoutDecoder(config.viewHash, config.viewFunction, optionsSet);
+    }
+}
+
+function removeDuplicates(arrArg: any[]): any[] {
+  return arrArg.filter((elem, pos, arr) => {
+    return arr.indexOf(elem) === pos;
+  });
+}
+
+// this is our render's file contents
+// basically just boilerplate
+export function generateRendererFileMany(hash: string, configs: ViewFunctionConfig[]): string {
+    const viewImports =
+        configs
+            .map((config) => importLine(config.viewFunction))
+            .join("\n");
+
+    const decoderImports =
+        configs
+            .map((config) => (config.decoder) ? importLine(config.decoder) + "\n" : "")
+            .join("");
+
+    const imports = viewImports + "\n" + decoderImports;
+
+    const initBody = init(configs);
+
+    const renderCommands =
+        configs
+            .map(generateBody)
+            .join("\n\n");
+
+    // duplicate ports are now allowed, so remove duplicates
+    const uniqueViewHashes = removeDuplicates(configs.map((config) => config.viewHash));
+
+    const ports =
+        uniqueViewHashes
+            .map((viewHash) => `port htmlOut${viewHash} : String -> Cmd msg`)
+            .join("\n");
 
     const rendererFileContents = `
-port module PrivateMain${viewHash} exposing (..)
+port module PrivateMain${hash} exposing (..)
 
 import Platform
 import Html exposing (Html)
@@ -93,13 +206,7 @@ ${imports}
 asJsonView : Html msg -> Json.Value
 asJsonView = Native.Jsonify.stringify
 
-${optionsSet}
-
-decode : Html msg -> String
-decode view =
-    case Json.decodeValue decodeElmHtml (asJsonView view) of
-        Err str -> "ERROR:" ++ str
-        Ok str -> nodeToStringWithOptions options str
+${renderCommands}
 
 ${initBody}
 
@@ -109,7 +216,13 @@ main = Platform.programWithFlags
     , subscriptions = (\\_ -> Sub.none)
     }
 
-port htmlOut${viewHash} : String -> Cmd msg
+${ports}
 `;
     return rendererFileContents;
+}
+
+export function generateRendererFile(
+    viewHash: string, viewFunction: string, decoderName: string, newLines: boolean, indent: number): string {
+    const config = { viewFunction, viewHash, decoder: decoderName, newLines, indent };
+    return generateRendererFileMany(viewHash, [config]);
 }

--- a/templates.ts
+++ b/templates.ts
@@ -132,7 +132,7 @@ export function generateRendererFile(hash: string, configs: ViewFunctionConfig[]
         .map((config) => `render${config.viewHash}`)
             .join(", ");
 
-    const port = `port htmlOut${hash} : List (String, String) -> Cmd msg`;
+    const port = `port htmlOut${hash} : List { generatedHtml : String, fileOutputName: String } -> Cmd msg`;
 
     return `
 port module PrivateMain${hash} exposing (..)
@@ -155,8 +155,14 @@ renderers = [ ${renderersList} ]
 
 init : List (String, Json.Value) -> ((), Cmd msg)
 init models =
-    let command =
-            List.map2 (\\renderer (identifier, model) -> (identifier, renderer model)) renderers models
+    let
+        mapper renderer (fileOutputName, model) =
+            { generatedHtml = renderer model
+            , fileOutputName = fileOutputName
+            }
+
+        command =
+            List.map2 mapper renderers models
                 |> htmlOut${hash}
     in
         ( (), command )

--- a/templates.ts
+++ b/templates.ts
@@ -132,7 +132,7 @@ export function generateRendererFile(hash: string, configs: ViewFunctionConfig[]
         .map((config) => `render${config.viewHash}`)
             .join(", ");
 
-    const port = `port htmlOut${hash} : List String -> Cmd msg`;
+    const port = `port htmlOut${hash} : List (String, String) -> Cmd msg`;
 
     return `
 port module PrivateMain${hash} exposing (..)
@@ -153,10 +153,10 @@ ${renderCommands}
 renderers : List (Json.Value -> String)
 renderers = [ ${renderersList} ]
 
-init : List Json.Value -> ((), Cmd msg)
+init : List (String, Json.Value) -> ((), Cmd msg)
 init models =
     let command =
-            List.map2 (\\renderer model -> renderer model) renderers models
+            List.map2 (\\renderer (identifier, model) -> (identifier, renderer model)) renderers models
                 |> htmlOut${hash}
     in
         ( (), command )

--- a/templates.ts
+++ b/templates.ts
@@ -91,10 +91,8 @@ render${viewHash} _ =
 function generateBody(config: ViewFunctionConfig): string {
     const optionsSet = generateOptionsSet(config.newLines, config.indent);
     if (config.decoder) {
-        console.log("withDecoder ->", config.decoder, config.viewFunction);
         return renderCommandWithDecoder(config.viewHash, config.viewFunction, config.decoder, optionsSet);
     } else {
-        console.log("withoutDecoder ->", config.decoder, config.viewFunction);
         return renderCommandWithoutDecoder(config.viewHash, config.viewFunction, optionsSet);
     }
 }


### PR DESCRIPTION
**my use case** 

I would like to use this library to generate a bunch of html templates (for hakyll). They all depend on 
the same style code, so in most cases, I want to regenerate all my templates when I change some elm code. 

Currently, putting all these view functions (about 10) in a .js file and calling this lib for all of them is too slow (5 seconds), because 10 elm files are generated and compiled (it also seems that my code
as it is imported, is compiled multiple times). 

**proposed fix**

Allow for putting multiple view functions together, compiling them into one elm file. This PR introduces 

```typescript
export interface ViewFunctionConfig {
    viewFunction: string;
    output: string;
    model?: any;
    decoder?: string;
    indent?: number;
    newLines?: boolean;
}

export function grouped(
    rootDir: string, moduleName: string, configs: ViewFunctionConfig[],
    alreadyRun?: boolean, elmMakePath?: string, installMethod?: string): Promise<void[]> 
```

*the moduleName argument is only used to generate a unique hash. Might be better to concatenate the view function names and take that as the hash)*

This function does the writing to file for you, because otherwise the user needs to keep track of the order of the view functions and then reassociate the rendered html with the correct output file later.

Alternatively we could still take the filename as an input but give back a `Promise<[[string, string]]>` where the first element is the rendered html and the other is the file name. 

<hr> 

Does this seem good architecturally? the PR actually contains code that implements this idea but it's not very pretty yet and I'd like to check whether this is the right idea first.
